### PR TITLE
Change OpenSearch Serverless index engine to FAISS

### DIFF
--- a/healthcare-life-sciences/automate-discharge-instructions/index-custom-resource/index_custom_resource.py
+++ b/healthcare-life-sciences/automate-discharge-instructions/index-custom-resource/index_custom_resource.py
@@ -104,8 +104,8 @@ def index_data(region, vector_index_name, text_field,
                     "type": "knn_vector",
                     "dimension": 1536,
                     "method": {
-                        "engine": "nmslib",
-                        "space_type": "cosinesimil",
+                        "engine": "faiss",
+                        "space_type": "l2",
                         "name": "hnsw"
                     }
                 }


### PR DESCRIPTION
*Issue #, if available:* fixes #4

*Description of changes:* Changed OpenSearch Serverless index engine to FAISS and space type to L2.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
